### PR TITLE
fix: pin ESPHome UART version

### DIFF
--- a/esphome.yaml
+++ b/esphome.yaml
@@ -27,8 +27,11 @@ esphome:
     monitor_filters: esp32_exception_decoder
 
 external_components:
-    source: github://Tysonpower/esphome-hcpbridge
+  - source: github://Tysonpower/esphome-hcpbridge
     refresh: 0s
+  - source: github://esphome/esphome@2025.9.3
+    refresh: 0s
+    components: [uart]
 
 esp32:
   variant: esp32s3

--- a/esphome_beta.yaml
+++ b/esphome_beta.yaml
@@ -5,12 +5,12 @@ substitutions:
   connection_state: "${name} Connected"
   relay_name: "${friendly_name} Relay state"
   light: "${friendly_name} Light"
-  btn_vent: "${friendly_name} Vent" 
-  btn_half: "${friendly_name} Half" 
-  btn_impulse: "${friendly_name} Impulse" 
-  sen_txt: "${friendly_name} State" 
-  sw_vent: "${friendly_name} Venting" 
-  sw_half: "${friendly_name} Open Half" 
+  btn_vent: "${friendly_name} Vent"
+  btn_half: "${friendly_name} Half"
+  btn_impulse: "${friendly_name} Impulse"
+  sen_txt: "${friendly_name} State"
+  sw_vent: "${friendly_name} Venting"
+  sw_half: "${friendly_name} Open Half"
 
 esphome:
   name: "${name}"
@@ -27,8 +27,11 @@ esphome:
     monitor_filters: esp32_exception_decoder
 
 external_components:
-    source: github://Tysonpower/esphome-hcpbridge
+  - source: github://Tysonpower/esphome-hcpbridge
     refresh: 0s
+  - source: github://esphome/esphome@2025.9.3
+    refresh: 0s
+    components: [uart]
 
 esp32:
   variant: esp32s3

--- a/esphome_e3.yaml
+++ b/esphome_e3.yaml
@@ -33,8 +33,11 @@ esphome:
     monitor_filters: esp32_exception_decoder
 
 external_components:
-    - source: github://Tysonpower/hoermann_door
-      refresh: 0s
+  - source: github://Tysonpower/esphome-hcpbridge
+    refresh: 0s
+  - source: github://esphome/esphome@2025.9.3
+    refresh: 0s
+    components: [uart]
 
 esp32:
   variant: esp32s3

--- a/esphome_e3_preflash.yaml
+++ b/esphome_e3_preflash.yaml
@@ -33,8 +33,11 @@ esphome:
     monitor_filters: esp32_exception_decoder
 
 external_components:
-    - source: github://Tysonpower/hoermann_door
-      refresh: 0s
+  - source: github://Tysonpower/esphome-hcpbridge
+    refresh: 0s
+  - source: github://esphome/esphome@2025.9.3
+    refresh: 0s
+    components: [uart]
 
 esp32:
   variant: esp32s3

--- a/esphome_preflash.yaml
+++ b/esphome_preflash.yaml
@@ -27,8 +27,11 @@ esphome:
     monitor_filters: esp32_exception_decoder
 
 external_components:
-    source: github://Tysonpower/esphome-hcpbridge
+  - source: github://Tysonpower/esphome-hcpbridge
     refresh: 0s
+  - source: github://esphome/esphome@2025.9.3
+    refresh: 0s
+    components: [uart]
 
 esp32:
   variant: esp32s3


### PR DESCRIPTION
Due to changes in ESPHome's handling of UART, sending actions to the door no longer worked.
This was detailed in this issue: https://github.com/14yannick/hoermann_door/issues/12#issuecomment-3438817248
This PR should fix this issue temporarily.