### PR TITLE
Add sensor IDs

### DIFF
--- a/esphome.yaml
+++ b/esphome.yaml
@@ -122,6 +122,7 @@ switch:
 
 sensor:
   - platform: bme280_i2c
+    id: sensor_bme280
     temperature:
       name: "BME280 Temperature"
     pressure:
@@ -131,6 +132,7 @@ sensor:
     address: 0x76 # can be 0x77 as well
     update_interval: 30s
   - platform: dht
+    id: sensor_dht
     pin: GPIO04
     temperature:
       name: "DHT Temperature"


### PR DESCRIPTION
This adds IDs to the two predefined sensors so their configuration can be extended, e.g. to fix a model for the DHT sensor:
```
sensor:
  - id: !extend sensor_dht
    model: AM2302
```