### PR TITLE
Add sensor sub-IDs

### DIFF
--- a/esphome.yaml
+++ b/esphome.yaml
@@ -125,10 +125,13 @@ sensor:
     id: sensor_bme280
     temperature:
       name: "BME280 Temperature"
+      id: sensor_bme280_temperature
     pressure:
       name: "BME280 Pressure"
+      id: sensor_bme280_pressure
     humidity:
       name: "BME280 Humidity"
+      id: sensor_bme280_humidity
     address: 0x76 # can be 0x77 as well
     update_interval: 30s
   - platform: dht
@@ -136,8 +139,10 @@ sensor:
     pin: GPIO04
     temperature:
       name: "DHT Temperature"
+      id: sensor_dht_temperature
     humidity:
       name: "DHT Humidity"
+      id: sensor_dht_humidity
     update_interval: 30s
 
 api:


### PR DESCRIPTION
Following https://github.com/Tysonpower/HCPBridgeMqtt_tynet/pull/61, this PR also adds specific IDs for all sub-sensors. This makes it easier to use the sensor values in the user config.

```
packages:
  tynet.hcpbridge_e4: github://Tysonpower/HCPBridgeMqtt_tynet/esphome.yaml@main
  
sensor:
  - platform: absolute_humidity
    name: Absolute Humidity
    id: sensor_bme280_absolute_humidity
    temperature: sensor_bme280_temperature
    humidity: sensor_bme280_humidity
```