### PR TITLE
fix: connect to the strongest AP on multi-AP networks

### DIFF
--- a/HCPBridgeESP32/WebUI/webpage/index.html
+++ b/HCPBridgeESP32/WebUI/webpage/index.html
@@ -202,6 +202,13 @@
 				<input type="text" id="wifi_ap_pass" name="wifi_ap_pass">
 			</div>
 			<div class="flex">
+				<div class="form-label">
+					<label for="wifi_best_ap">Connect to strongest AP</label>
+					<small>Scan all channels (multi-AP / mesh networks)</small>
+				</div>
+				<input type="checkbox" id="wifi_best_ap" name="wifi_best_ap">
+			</div>
+			<div class="flex">
 				<label for="hostname">Hostname</label>
 				<input type="text" id="hostname" name="hostname">
 			</div>

--- a/HCPBridgeESP32/src/main.cpp
+++ b/HCPBridgeESP32/src/main.cpp
@@ -103,6 +103,18 @@ void resetPreferences() {
 void connectToWifi() {
     if (localPrefs->getString(preference_wifi_ssid) != "") {
         DBG_PRINTLN("Connecting to Wi-Fi...");
+        // Multi-AP networks (same SSID on several APs): arduino-esp32 defaults to
+        // WIFI_FAST_SCAN, which associates with the FIRST matching AP found and
+        // stops - regardless of RSSI. The bridge then sticks to a far/weak AP and
+        // re-attaches to the same BSSID after every reconnect. Scanning all
+        // channels first makes WIFI_CONNECT_AP_BY_SIGNAL effective, so the
+        // strongest AP wins. Costs a full scan at boot/reconnect only.
+        if (localPrefs->getBool(preference_wifi_best_ap, true)) {
+            WiFi.setScanMethod(WIFI_ALL_CHANNEL_SCAN);
+            WiFi.setSortMethod(WIFI_CONNECT_AP_BY_SIGNAL);
+        } else {
+            WiFi.setScanMethod(WIFI_FAST_SCAN);
+        }
         WiFi.begin(localPrefs->getString(preference_wifi_ssid).c_str(), localPrefs->getString(preference_wifi_password).c_str(), 0, nullptr, true);
     } else {
         DBG_PRINTLN("No WiFi Client enabled");

--- a/HCPBridgeESP32/src/preferences_handler.cpp
+++ b/HCPBridgeESP32/src/preferences_handler.cpp
@@ -139,6 +139,7 @@ void PreferenceHandler::saveConf(JsonDocument& doc) {
     if (saveBasic) {
         preferences->putBool(preference_wifi_ap_mode, !doc[preference_wifi_ap_mode].isNull() && doc[preference_wifi_ap_mode].as<String>() == "on");
         preferences->putBool(preference_debug_enabled, !doc[preference_debug_enabled].isNull() && doc[preference_debug_enabled].as<String>() == "on");
+        preferences->putBool(preference_wifi_best_ap, !doc[preference_wifi_best_ap].isNull() && doc[preference_wifi_best_ap].as<String>() == "on");
     }
 
     if (saveSensor) {

--- a/HCPBridgeESP32/src/preferences_handler.h
+++ b/HCPBridgeESP32/src/preferences_handler.h
@@ -32,6 +32,8 @@
 #define preference_wifi_password "wifi_pass"
 #define preference_www_password "www_pass"
 #define preference_wifi_ap_password "wifi_ap_pass"
+// Scan all channels and associate with the strongest BSSID of the SSID
+#define preference_wifi_best_ap "wifi_best_ap"
 
 // Debug
 #define preference_debug_enabled "debug_enabled"
@@ -124,6 +126,7 @@ static const PrefDef PREF_REGISTRY[] = {
     {preference_wifi_ssid,          PrefType::STRING, false,  PREF_GROUP_BASIC,    STA_SSID,       0,              0.0,        false},
     {preference_wifi_password,      PrefType::STRING, true,   PREF_GROUP_BASIC,    STA_PASSWD,     0,              0.0,        false},
     {preference_wifi_ap_password,   PrefType::STRING, true,   PREF_GROUP_BASIC,    AP_PASSWD,      0,              0.0,        false},
+    {preference_wifi_best_ap,       PrefType::BOOL,   false,  PREF_GROUP_BASIC,    "",             0,              0.0,        true},
     {preference_www_password,       PrefType::STRING, true,   PREF_GROUP_BASIC,    WWW_PASSWD,     0,              0.0,        false},
     {preference_mqtt_server,        PrefType::STRING, false,  PREF_GROUP_BASIC,    MQTTSERVER,     0,              0.0,        false},
     {preference_mqtt_server_port,   PrefType::INT,    false,  PREF_GROUP_BASIC,    "",             MQTTPORT,       0.0,        false},

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you don't use Home Assistant you can modify the yaml configuration to use MQT
 - Web Interface for configuration & control  
 - OTA Updates  
 - First-use hotspot (for out-of-the-box Wi-Fi setup) 
+- Connects to the strongest AP if the SSID is broadcast by several access points
 - Optional external sensors (DS18x20, BME280, DHT22, HC-SR04, HC-SR501, MQ4)
 - Efficient MQTT traffic (only publish on state change)  
 - Support multiple HCP Bridges for multiple garage doors (one bridge per motor)
@@ -61,6 +62,15 @@ You can use the WebUI for configuration and control of the garage door under.
 
 <img width="632" height="790" alt="image" src="https://github.com/user-attachments/assets/a3b047f2-63ca-4785-bbc7-5dc1dd7dba2c" />
 
+<br>
+
+## Wi-Fi in multi-AP networks
+
+If the same SSID is broadcast by several access points (UniFi, mesh, repeaters), leave **Connect to strongest AP** enabled in the basic configuration (default: on). The device then scans all channels and associates with the AP with the best signal, instead of the first one it happens to find. Without it the bridge can stay attached to a far AP at a very weak signal and re-attach to that same AP after every reconnect, so it cannot be moved from the network side.
+
+Turn it off to get the slightly faster (but signal-agnostic) fast scan on single-AP networks.
+
+For the ESPHome based firmware the equivalent is `fast_connect: false` in the `wifi:` block (the default).
 
 <br><br><br><br><br><br><br><br><br><br>
 

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -189,6 +189,11 @@ web_server:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  # Multi-AP networks (same SSID on several APs, e.g. UniFi/mesh):
+  # fast_connect must stay false (the default) - ESPHome then scans all
+  # channels and associates with the AP that has the strongest signal instead
+  # of the first one found. Only set it to true for hidden SSIDs.
+  fast_connect: false
   ap:
     ssid: "HCPBRIDGE"
     password: !secret hcp_wifi_ap_password

--- a/esphome_e3.yaml
+++ b/esphome_e3.yaml
@@ -53,6 +53,11 @@ i2c:
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
+  # Multi-AP networks (same SSID on several APs, e.g. UniFi/mesh):
+  # fast_connect must stay false (the default) - ESPHome then scans all
+  # channels and associates with the AP that has the strongest signal instead
+  # of the first one found. Only set it to true for hidden SSIDs.
+  fast_connect: false
   ap:
     ssid: "HCPBRIDGE"
     password: !secret hcp_wifi_ap_password


### PR DESCRIPTION
Ports the Wi-Fi fix from upstream (`Gifford47/HCPBridgeMqtt@a4db0dd1`, their issue [#144](https://github.com/Gifford47/HCPBridgeMqtt/issues/144)) to this fork.

## Problem

arduino-esp32 defaults to `WIFI_FAST_SCAN`, which associates with the **first** matching AP found during the channel scan and stops — regardless of RSSI. On networks where several APs broadcast the same SSID (UniFi, mesh, repeaters) the bridge can sit on a far AP at a very weak signal and re-attach to that same BSSID after every reconnect, so it cannot be moved from the network side either.

On my own bridge (Tynet board, ESP32-S3) it was stuck at **−90 dBm / 1 Mbps** on an upstairs AP while the nearest AP sits **0.4 m away**. Kicking the client, lowering TX power on the far AP and moving the near AP to the same channel all failed — it always came back to the far one.

## Change

`connectToWifi()` now selects `WIFI_ALL_CHANNEL_SCAN` + `WIFI_CONNECT_AP_BY_SIGNAL`, which is what actually makes the signal-based selection take effect (`WIFI_CONNECT_AP_BY_SIGNAL` is a no-op with fast scan). Exposed as a new preference `wifi_best_ap` — *Connect to strongest AP*, default **on**; switching it off restores the faster fast scan for single-AP networks. The trade-off is a full channel scan at boot/reconnect only, which is negligible for a stationary device.

The ESPHome configs get the equivalent note and an explicit `fast_connect: false`.

## Testing

Built with `pio run -e HCP_Tynet` (942 KB) and flashed via ElegantOTA onto a Tynet board that was previously running 0.0.8.0:

| | before | after |
|---|---|---|
| firmware | 0.0.8.0 | 1.0.7 + this patch |
| RSSI | −90 dBm | **−33 dBm** |

It now associates with the near AP, MQTT reconnects, the bus stays valid and door/light commands work. Existing preferences and all Home Assistant entities survived the update unchanged.

The C++ and WebUI changes are upstream's commit unmodified; only `README.md` and the ESPHome YAMLs were adapted to this fork's layout. `WebUI/index_html.h` is left alone since `compress.py` regenerates it at build time.